### PR TITLE
add jq

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ USER root
 RUN chmod +x /usr/local/bin/setup_kubectl.sh
 
 RUN apt-get update -qy \
- && apt-get install -qy make gettext-base \
+ && apt-get install -qy make gettext-base jq \
  && curl -sLo /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_RELEASE}/bin/linux/amd64/kubectl \
  && cd /usr/bin/ \
  && sha256sum -c /tmp/SHA256SUMS.kubectl \


### PR DESCRIPTION
Per https://stedolan.github.io/jq/download, just apt-get jq. And what's kubectl without jq?